### PR TITLE
Stop GTG check sending to S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,4 @@ vendor/
 
 # Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
 .glide/
+generic-rw-s3

--- a/main.go
+++ b/main.go
@@ -1,6 +1,11 @@
 package main
 
 import (
+	"net"
+	"net/http"
+	"os"
+	"time"
+
 	"github.com/Financial-Times/base-ft-rw-app-go/baseftrwapp"
 	"github.com/Financial-Times/generic-rw-s3/service"
 	"github.com/Financial-Times/message-queue-gonsumer/consumer"
@@ -10,10 +15,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/gorilla/mux"
 	"github.com/jawher/mow.cli"
-	"net"
-	"net/http"
-	"os"
-	"time"
 )
 
 const (
@@ -133,7 +134,7 @@ func main() {
 }
 
 func runServer(port string, awsRegion string, bucketName string, bucketPrefix string, wrks int, qConf consumer.QueueConfig) {
-	hc := http.Client{
+	hc := &http.Client{
 		Transport: &http.Transport{
 			Proxy: http.ProxyFromEnvironment,
 			DialContext: (&net.Dialer{
@@ -151,7 +152,7 @@ func runServer(port string, awsRegion string, bucketName string, bucketPrefix st
 		&aws.Config{
 			Region:     aws.String(awsRegion),
 			MaxRetries: aws.Int(1),
-			HTTPClient: &hc,
+			HTTPClient: hc,
 		})
 	if err != nil {
 		log.Fatalf("Failed to create AWS session: %v", err)

--- a/service/handlers.go
+++ b/service/handlers.go
@@ -59,6 +59,7 @@ func (c *checker) healthCheck() (string, error) {
 
 func (c *checker) gtgCheckHandler(rw http.ResponseWriter, r *http.Request) {
 	if _, err := c.healthCheck(); err != nil {
+		log.Info("Healthcheck failed, gtg is bad.")
 		rw.WriteHeader(http.StatusServiceUnavailable)
 		return
 	}

--- a/service/handlers_test.go
+++ b/service/handlers_test.go
@@ -3,10 +3,6 @@ package service
 import (
 	"bytes"
 	"errors"
-	status "github.com/Financial-Times/service-status-go/httphandlers"
-	log "github.com/Sirupsen/logrus"
-	"github.com/gorilla/mux"
-	"github.com/stretchr/testify/assert"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -14,6 +10,11 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	status "github.com/Financial-Times/service-status-go/httphandlers"
+	log "github.com/Sirupsen/logrus"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
 )
 
 const (

--- a/service/processor.go
+++ b/service/processor.go
@@ -3,18 +3,19 @@ package service
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/Financial-Times/message-queue-gonsumer/consumer"
-	log "github.com/Sirupsen/logrus"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
+
+	"github.com/Financial-Times/message-queue-gonsumer/consumer"
+	log "github.com/Sirupsen/logrus"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 )
 
 type QProcessor interface {


### PR DESCRIPTION
The GTG was sending an object to S3, which was then triggering the notifications set up on the bucket.  The check has been changed to use the healthcheck (HEAD check on the bucket).