### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/upp-concepts-rw-s3_runbook.md
+++ b/runbooks/upp-concepts-rw-s3_runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - Concepts Read/Write S3
 
 Writing JSON representations of concepts to S3 via /concept/{uuid} endpoints.
@@ -8,7 +12,7 @@ upp-concepts-rw-s3
 
 ## Primary URL
 
-<https://upp-prod-publish-glb.upp.ft.com/__concepts-rw-s3/>
+https://upp-prod-publish-glb.upp.ft.com/__concepts-rw-s3/
 
 ## Service Tier
 
@@ -17,26 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- kalin.arsov
-- ivan.nikolov
-- hristo.georgiev
-- elitsa.pavlova
-- georgi.ivanov
-- dimitar.terziev
-- marina.chompalova
-- miroslav.gatsanoga
-- asparuh.filipov
 
 ## Host Platform
 
@@ -54,6 +38,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -93,6 +91,14 @@ Manual
 
 It is deployed with Jenkins job
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 Manual
@@ -104,8 +110,8 @@ To rotate credentials you need to login to a particular cluster and update varni
 
 ## Monitoring
 
-- Delivery PROD EU Health: <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=concepts-rw-s3>
-- Delivery PROD US Health : <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=concepts-rw-s3>
+*   Delivery PROD EU Health: <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=concepts-rw-s3>
+*   Delivery PROD US Health : <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=concepts-rw-s3>
 
 ## First Line Troubleshooting
 

--- a/runbooks/upp-generic-rw-s3_runbook.md
+++ b/runbooks/upp-generic-rw-s3_runbook.md
@@ -1,3 +1,7 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP - Generic Read/Write S3
 
 Reads CES suggestion messages off kafka and stores them in S3; can also read/write/delete S3 objects via /{uuid} endpoints.
@@ -8,7 +12,7 @@ upp-generic-rw-s3
 
 ## Primary URL
 
-<https://upp-prod-delivery-glb.upp.ft.com/__generic-rw-s3/>
+https://upp-prod-delivery-glb.upp.ft.com/__generic-rw-s3/
 
 ## Service Tier
 
@@ -17,26 +21,6 @@ Bronze
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- kalin.arsov
-- ivan.nikolov
-- hristo.georgiev
-- elitsa.pavlova
-- georgi.ivanov
-- dimitar.terziev
-- marina.chompalova
-- miroslav.gatsanoga
-- asparuh.filipov
 
 ## Host Platform
 
@@ -54,6 +38,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -92,6 +90,14 @@ Manual
 
 It is deployed with Jenkins job
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 Manual
@@ -103,8 +109,8 @@ To rotate credentials you need to login to a particular cluster and update varni
 
 ## Monitoring
 
-- Delivery PROD EU Health: <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=generic-rw-s3>
-- Delivery PROD US Health : <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=generic-rw-s3>
+*   Delivery PROD EU Health: <https://upp-prod-delivery-eu.upp.ft.com/__health/__pods-health?service-name=generic-rw-s3>
+*   Delivery PROD US Health : <https://upp-prod-delivery-us.upp.ft.com/__health/__pods-health?service-name=generic-rw-s3>
 
 ## First Line Troubleshooting
 


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/generic-rw-s3/blob/runbook-no-relationships-2021-03-19/runbooks/upp-generic-rw-s3_runbook.md) file has been automatically regenerated from the Biz Ops data for the **upp-generic-rw-s3** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **upp-generic-rw-s3** system in [Biz Ops](https://biz-ops.in.ft.com/System/upp-generic-rw-s3).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
